### PR TITLE
PHP_CodeSniffer: PHPCompatibility standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Other packages that you'll get:
 * **[Composer Versions Check]**: Checks if packages are up to date to last major versions after update
 * **[Mink Goutte Driver]**: Goutte driver for Mink framework
 * **[Mink Selenium2 Driver]**: Selenium2 (WebDriver) driver for Mink framework
+* **[PHP_CodeSniffer Composer Installer]**: For installing PHP_CodeSniffer coding standards
+* **[PHPCompatibility]**: PHP Compatibility checks for PHP_CodeSniffer
 * **[prestissimo]**: Composer parallel install plugin
 
 The following packages are suggested:
@@ -73,6 +75,8 @@ The following packages are suggested:
 [Composer Versions Check]: https://github.com/Soullivaneuh/composer-versions-check
 [Mink Goutte Driver]: https://github.com/minkphp/MinkGoutteDriver
 [Mink Selenium2 Driver]: https://github.com/minkphp/MinkSelenium2Driver
+[PHP_CodeSniffer Composer Installer]: https://github.com/DealerDirect/php-qa-tools
+[PHPCompatibility]: https://github.com/wimg/PHPCompatibility
 [prestissimo]: https://github.com/hirak/prestissimo
 
 [ApiGen]: http://www.apigen.org

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,14 @@
     "php": ">=5.6,<8.0-dev",
 
     "hirak/prestissimo": "^0.3",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.2.0",
 
     "behat/behat": "^3.1.0",
     "behat/mink": "^1.7.0",
     "behat/mink-goutte-driver": "^1.2.0",
     "brianium/paratest": ">=0.14.0,<1.0.0",
     "codeception/codeception": "^2.2.0",
+    "frenck/php-compatibility": "^7.0.0",
     "friendsofphp/php-cs-fixer": "^1.12.1",
     "jakub-onderka/php-parallel-lint": ">=0.9.1,<1.0.0",
     "phploc/phploc": "^3.0.1",


### PR DESCRIPTION
Added packages: wimg/php-compatibility (actually frenck/php-compatibility) and dealerdirect/phpcodesniffer-composer-installer.