### PR TITLE
Fixed issue with Ocramius Package Versions and PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,9 @@
     "sensiolabs/security-checker": "^4.0",
     "sllh/composer-versions-check": "^2.0.0",
     "sstalle/php7cc": "^1.1.0",
-    "squizlabs/php_codesniffer": "^2.5"
+    "squizlabs/php_codesniffer": "^2.5",
+
+    "ocramius/proxy-manager": "^1.0.0"
   },
   "suggest": {
     "apigen/apigen": "Smart and Readable Documentation for your PHP project.",


### PR DESCRIPTION
This fixes an issue with Ocramius Package Versions.

This packages is included by the Orcramius Proxy Manager package when using PHP 7+ and causes problems when the Dealerdirect PHP QA Tools are installed globally.

For more information / progress on the issue see:

https://github.com/Ocramius/PackageVersions/issues/38