### PR TITLE
Added Tombstone Analyzer for Tombstone report generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
   - ./vendor/bin/parallel-lint -h
   - ./vendor/bin/phpcs --version
   - ./vendor/bin/pdepend --version
-  - ./vendor/bin/php7cc --version
   - ./vendor/bin/phpcpd --version
   - ./vendor/bin/phploc --version
   - ./vendor/bin/phpmetrics --version

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Other packages that you'll get:
 * **[PHP_CodeSniffer Composer Installer]**: For installing PHP_CodeSniffer coding standards
 * **[PHPCompatibility]**: PHP Compatibility checks for PHP_CodeSniffer
 * **[prestissimo]**: Composer parallel install plugin
+* **[Tombstone Analyzer]**: Report generation for Tombstones
 
 ## Suggested
 
@@ -83,6 +84,7 @@ The following packages are suggested:
 [PhpMetrics]: http://www.phpmetrics.org
 [PHPUnit]: https://phpunit.de
 [SensioLabs Security Checker]: https://security.sensiolabs.org
+[Tombstone Analyzer]: https://github.com/scheb/tombstone-analyzer
 
 [Behat Mink]: https://github.com/Behat/MinkExtension
 [Composer Versions Check]: https://github.com/Soullivaneuh/composer-versions-check

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ You'll get the following tools by depending on this package:
 * **[PHP Coding Standards Fixer]**: A tool to automatically fix PHP coding standards issues
 * **[PHP Parallel Lint]**: Check syntax of PHP files faster than serial check with fancier output
 * **[PHP_CodeSniffer]**: Detects violations of a defined set of coding standards
-* **[php7cc]**: PHP 7 Compatibility Checker
 
 ### Quality Assistance
 
@@ -77,7 +76,6 @@ The following packages are suggested:
 [PHP Parallel Lint]: https://github.com/JakubOnderka/PHP-Parallel-Lint
 [PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer
 [PHP_Depend]: https://github.com/pdepend/pdepend
-[php7cc]: https://github.com/sstalle/php7cc
 [PHPCPD]: https://github.com/sebastianbergmann/phpcpd
 [PHPLOC]: https://github.com/sebastianbergmann/phploc
 [PHPMD]: https://phpmd.org

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
     "seld/jsonlint": "^1.4.0",
     "sensiolabs/security-checker": "^4.0",
     "sllh/composer-versions-check": "^2.0.0",
-    "sstalle/php7cc": "^1.1.0",
     "squizlabs/php_codesniffer": "^2.5",
     "scheb/tombstone-analyzer": "^0.3.0",
 

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "sllh/composer-versions-check": "^2.0.0",
     "sstalle/php7cc": "^1.1.0",
     "squizlabs/php_codesniffer": "^2.5",
+    "scheb/tombstone-analyzer": "^0.3.0",
 
     "ocramius/proxy-manager": "^1.0.0"
   },


### PR DESCRIPTION
Added tombstone-analyzer.
Removed php7cc, because of an outdated dependency, which causes a conflict with the tombstone-analyzer.