### PR TITLE
Removed Humbug, since it is not stable yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ You'll get the following tools by depending on this package:
 
 - **[Behat][behat]**: BDD framework for PHP
 - **[Codeception][codeception]**: Modern full-stack testing framework for PHP
-- **[Humbug][humbug]**: Humbug is a Mutation Testing framework for PHP
 - **[Mink][mink]**: PHP 5.3+ web browser emulator abstraction
 - **[ParaTest][paratest]**: Parallel testing for PHPUnit
 - **[PHPUnit][phpunit]**: Testing framework for PHP
@@ -216,7 +215,6 @@ THE SOFTWARE.
 [frenck]: https://github.com/frenck
 [get-in-touch]: http://workingatdealerdirect.eu/open-sollicitatie/
 [grumphp]: https://github.com/phpro/grumphp
-[humbug]: https://github.com/padraic/humbug
 [json-lint]: https://github.com/Seldaek/jsonlint
 [license-shield]: https://img.shields.io/github/license/dealerdirect/php-qa-tools.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2017.svg

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     "frenck/php-compatibility": "^7.0.0",
     "friendsofphp/php-cs-fixer": "^2.0.0",
     "hirak/prestissimo": "^0.3",
-    "humbug/humbug": "~1.0@dev",
     "jakub-onderka/php-parallel-lint": ">=0.9.1,<1.0.0",
     "pdepend/pdepend": "^2.2.0",
     "phing/phing": "^2.0.0",


### PR DESCRIPTION
## Proposed Changes

Removal of Humbug from the toolset. Since it is not stable, this may cause issues in our projects.

## Related Issues

For more information about stability markers in meta packages:
https://github.com/composer/composer/issues/5424