### PR TITLE
Adds scrutinizer-ci/ocular

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - gpg --verify ./bin/install.sh.sig
   - shellcheck ./bin/install.sh
   - composer validate
-  - composer install --no-progress --no-suggest
+  - travis_wait composer install --no-progress --no-suggest
   - yarn install --no-progress
   - yarn run test
   - ./vendor/bin/behat --version

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You'll get the following tools by depending on this package:
 - **[Behat][behat]**: BDD framework for PHP
 - **[Codeception][codeception]**: Modern full-stack testing framework for PHP
 - **[Mink][mink]**: PHP 5.3+ web browser emulator abstraction
+- **[Ocular][ocular]**: CLI for uploading external code coverage data to Scrutinizer
 - **[ParaTest][paratest]**: Parallel testing for PHPUnit
 - **[PHPUnit][phpunit]**: Testing framework for PHP
 
@@ -212,8 +213,8 @@ THE SOFTWARE.
 [behat]: http://behat.org
 [codeception]: http://codeception.com
 [contributors]: https://github.com/dealerdirect/php-qa-tools/graphs/contributors
-[deployer]: https://deployer.org
 [deployer-recipes]: https://github.com/deployphp/recipes
+[deployer]: https://deployer.org
 [frenck]: https://github.com/frenck
 [get-in-touch]: http://workingatdealerdirect.eu/open-sollicitatie/
 [grumphp]: https://github.com/phpro/grumphp
@@ -224,6 +225,7 @@ THE SOFTWARE.
 [mink-selenium2-driver]: https://github.com/minkphp/MinkSelenium2Driver
 [mink]: http://mink.behat.org
 [mockery]: https://github.com/padraic/mockery
+[ocular]: https://github.com/scrutinizer-ci/ocular
 [packagist-shield]: https://img.shields.io/packagist/dt/dealerdirect/qa-tools.svg
 [packagist-version-shield]: https://img.shields.io/packagist/v/dealerdirect/qa-tools.svg
 [packagist-version]: https://packagist.org/packages/dealerdirect/qa-tools

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     "phpro/grumphp": ">=0.11.0,<1.0.0",
     "phpunit/phpunit": "^5.5.0",
     "scheb/tombstone-analyzer": "^0.3.0",
+    "scrutinizer/ocular": "^1.3",
     "sebastian/phpcpd": "^3.0.0",
     "seld/jsonlint": "^1.4.0",
     "sensiolabs/security-checker": "^4.0",


### PR DESCRIPTION
## Proposed Changes

To add `scrutinizer-ci/ocular`.
This tool allows uploading PHPUnit coverage data into Scrutinizer.

Currently our CI containers install this package manually.

## Related Issues

None.