### PR TITLE
Build/PHPCS: update PHPCompatibility repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ THE SOFTWARE.
 [phinx]: https://phinx.org
 [php-codebrowser]: https://github.com/mayflower/PHP_CodeBrowser
 [php-parallel-lint]: https://github.com/JakubOnderka/PHP-Parallel-Lint
-[phpcompatibility]: https://github.com/wimg/PHPCompatibility
+[phpcompatibility]: https://github.com/PHPCompatibility/PHPCompatibility
 [phpcov]: https://github.com/sebastianbergmann/phpcov
 [phpcpd]: https://github.com/sebastianbergmann/phpcpd
 [phpcs-composer-installer]: https://github.com/Dealerdirect/phpcodesniffer-composer-installer

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "hirak/prestissimo": "^0.3",
     "jakub-onderka/php-parallel-lint": ">=0.9.1,<1.0.0",
     "pdepend/pdepend": "^2.5",
+    "phpcompatibility/php-compatibility": "^8.0",
     "phploc/phploc": "^4.0",
     "phpmd/phpmd": "^2.6.0",
     "phpmetrics/phpmetrics": "^2.3.2",
@@ -44,8 +45,7 @@
     "seld/jsonlint": "^1.6",
     "sensiolabs/security-checker": "^4.1",
     "sllh/composer-versions-check": "^2.0",
-    "squizlabs/php_codesniffer": "^3.2",
-    "wimg/php-compatibility": "^8.0"
+    "squizlabs/php_codesniffer": "^3.2"
   },
   "suggest": {
     "apigen/apigen": "Smart and Readable Documentation for your PHP project.",


### PR DESCRIPTION
## Proposed Changes

Switches the `PHPCompatibility` dependency over to use the repo in the `PHPCompatibility` GitHub organisation rather than the one in `wimg`'s personal account.

Includes updating the reference to the repo in the `Readme.md` file.

## Related Issues (References):
* https://github.com/PHPCompatibility/PHPCompatibility/issues/688
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0