### PR TITLE
Updated security-checker to version 5, 4 is not working any more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "scheb/tombstone-analyzer": "^0.3",
     "sebastian/phpcpd": "^3.0",
     "seld/jsonlint": "^1.6",
-    "sensiolabs/security-checker": "^4.1",
+    "sensiolabs/security-checker": "^5.0",
     "sllh/composer-versions-check": "^2.0",
     "squizlabs/php_codesniffer": "^3.2"
   },


### PR DESCRIPTION
## Proposed Changes

Updated security-checker to version 5

## Related Issues

```
security-checker -n security:check                                                                                                                                                                                                                                                            
An error occurred: Could not resolve host: security.sensiolabs.org.  
```

- https://github.com/sensiolabs/security-checker/issues/149
- https://twitter.com/fabpot/status/1099994260051582978
