### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "hirak/prestissimo": "^0.3",
     "jakub-onderka/php-parallel-lint": ">=0.9.1,<1.0.0",
     "pdepend/pdepend": "^2.5",
-    "phpcompatibility/php-compatibility": "^8.0",
+    "phpcompatibility/php-compatibility": "^9.0",
     "phploc/phploc": "^4.0",
     "phpmd/phpmd": "^2.6.0",
     "phpmetrics/phpmetrics": "^2.3.2",


### PR DESCRIPTION
## Proposed Changes

Use the latest version of PHPCompatibility.
You were missing out on a lot of new checks, including the checks to make sure code is compatible with the upcoming PHP 7.4.

Note: PHPCompatibility 9.0 renamed all the sniffs, so any inline selective ignores `// phpcs:ignore Stnd.Cat.Sniff` annotations will need to be updated (if used at all).

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0
