### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "deployer/deployer": "^4.3",
     "deployer/recipes": "^4.0",
     "friendsofphp/php-cs-fixer": "^2.8",
-    "hirak/prestissimo": "^0.3",
     "jakub-onderka/php-parallel-lint": ">=0.9.1,<1.0.0",
     "pdepend/pdepend": "^2.5",
     "phpcompatibility/php-compatibility": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": ">=5.6,<8.0-dev",
     "brianium/paratest": ">=0.14|^1.0",
     "codeception/codeception": "^2.3",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "deployer/deployer": "^4.3",
     "deployer/recipes": "^4.0",
     "friendsofphp/php-cs-fixer": "^2.8",


### PR DESCRIPTION
Removes hirak/prestissimo
As it's not needed in composer 2.0

## Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([GitHub link](https://help.github.com/articles/autolinked-references-and-urls/) to related issues or pull requests)
